### PR TITLE
Restore version 1.0.0 source code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Scrivito Icon Editor
+# JustRelate Icon Picker
 
-The `scrivito-icon-editor` is a versatile icon picker designed for seamless integration with [Scrivito](https://www.scrivito.com) and React applications. It supports [Bootstrap Icons](https://icons.getbootstrap.com) out of the box but can work with any icon set. Easily integrate it into your projects to add icons with custom styling and functionality.
+The `@justrelate/icon-picker` is a versatile icon picker designed for seamless integration with [Scrivito](https://www.scrivito.com) and React applications. It supports [Bootstrap Icons](https://icons.getbootstrap.com) out of the box but can work with any icon set. Easily integrate it into your projects to add icons with custom styling and functionality.
 
 ## Installation
 
 ```sh
-npm install scrivito-icon-editor
+npm install @justrelate/icon-picker
 ```
 
 ## Usage
@@ -14,12 +14,12 @@ npm install scrivito-icon-editor
 
 ```ts
 // IconWidgetEditingConfig.ts
-import { ScrivitoBootstrapIconEditor } from 'scrivito-icon-editor'
+import { ScrivitoBootstrapIconPicker } from '@justrelate/icon-picker'
 
 provideEditingConfig(IconWidget, {
   propertiesGroups: [
     {
-      component: ScrivitoBootstrapIconEditor,
+      component: ScrivitoBootstrapIconPicker,
       key: 'icon-group',
       properties: ['icon'],
       title: 'Icon',
@@ -30,24 +30,24 @@ provideEditingConfig(IconWidget, {
 
 #### Importing styles
 
-The `ScrivitoBootstrapIconEditor` includes built-in styles for easy integration. To apply these styles, import the following CSS files in your project:
+The `ScrivitoBootstrapIconPicker` includes built-in styles for easy integration. To apply these styles, import the following CSS files in your project:
 
 ```scss
 // scrivitoExtensions.scss
 @import 'bootstrap-icons/font/bootstrap-icons.css';
-@import 'scrivito-icon-editor/ScrivitoIconEditor.css';
+@import '@justrelate/icon-picker/ScrivitoIconPicker.css';
 ```
 
 #### Using the icon editor with options
 
 ```tsx
 // defaultPageEditingConfig.tsx
-import { ScrivitoBootstrapIconEditor } from 'scrivito-icon-editor'
+import { ScrivitoBootstrapIconPicker } from '@justrelate/icon-picker'
 
 export const defaultPagePropertiesGroups = [
   {
     component: (props: { page: Obj }) => (
-      <ScrivitoBootstrapIconEditor
+      <ScrivitoBootstrapIconPicker
         attribute="linkIcon"
         description="This icon may appear in a vertical navigation widget, for example."
         showClearButton
@@ -79,7 +79,7 @@ The Bootstrap icon picker features built-in support for Bootstrap Icons, making 
 
 ```tsx
 import 'bootstrap-icons/font/bootstrap-icons.css'
-import { BootstrapIconPicker } from 'scrivito-icon-editor'
+import { BootstrapIconPicker } from '@justrelate/icon-picker'
 
 function BoostrapIconPickerDemo() {
   const [icon, setIcon] = useState<string | undefined>('rocket-takeoff')
@@ -108,7 +108,7 @@ function BoostrapIconPickerDemo() {
 The generic icon picker is designed to work seamlessly with any React application and any icon set, providing you with the flexibility to choose icons that best suit your project’s needs. For optimal styling, ensure to include the relevant CSS to adjust the picker’s appearance according to your design requirements.
 
 ```tsx
-import { IconPicker } from 'scrivito-icon-editor'
+import { IconPicker } from '@justrelate/icon-picker'
 
 function IconPickerDemo() {
   const [icon, setIcon] = useState<string | undefined>('rocket')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "scrivito-icon-editor",
-  "version": "0.0.2",
+  "name": "@justrelate/icon-picker",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "scrivito-icon-editor",
-      "version": "0.0.2",
+      "name": "@justrelate/icon-picker",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/react": "^18.3.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,14 @@
 {
-  "name": "scrivito-icon-editor",
-  "version": "0.0.3",
+  "name": "@justrelate/icon-picker",
+  "version": "1.0.0",
+  "description": "A versatile icon picker for Scrivito and React applications with Bootstrap Icons support",
+  "keywords": [
+    "icon-picker",
+    "scrivito",
+    "react",
+    "bootstrap-icons",
+    "icon-editor"
+  ],
   "type": "module",
   "exports": {
     ".": "./dist/index.js",
@@ -12,7 +20,9 @@
     "dist"
   ],
   "types": "./dist/index.d.ts",
-  "repository": "github:JustRelate/scrivito-icon-editor",
+  "repository": "github:JustRelate/icon-picker",
+  "bugs": "https://github.com/JustRelate/icon-picker/issues",
+  "homepage": "https://github.com/JustRelate/icon-picker#readme",
   "scripts": {
     "build": "rm -rf dist && tsc && cp src/*.css dist",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",

--- a/src/ScrivitoBootstrapIconPicker.tsx
+++ b/src/ScrivitoBootstrapIconPicker.tsx
@@ -2,8 +2,8 @@ import type { Widget, Obj } from 'scrivito'
 import { uiContext, canEdit, connect, isInPlaceEditingActive } from 'scrivito'
 import { BootstrapIconPicker } from './BootstrapIconPicker.js'
 
-export const ScrivitoBootstrapIconEditor = connect(
-  function ScrivitoBootstrapIconEditor({
+export const ScrivitoBootstrapIconPicker = connect(
+  function ScrivitoBootstrapIconPicker({
     attribute,
     description,
     obj,
@@ -31,7 +31,7 @@ export const ScrivitoBootstrapIconEditor = connect(
       isInPlaceEditingActive() && canEdit(obj || page || widget.obj())
 
     return theme ? (
-      <div className={`scrivito_${theme} scrivito-icon-editor`}>
+      <div className={`scrivito_${theme} scrivito-icon-picker`}>
         <div className="description">{description}</div>
         <div className="preview-title">{previewTitle ?? 'Preview'}</div>
         <BootstrapIconPicker

--- a/src/ScrivitoIconPicker.css
+++ b/src/ScrivitoIconPicker.css
@@ -1,4 +1,4 @@
-.scrivito-icon-editor {
+.scrivito-icon-picker {
   --icon-clear-shadow-color: rgba(255, 255, 255, 0.2);
   --icon-description-color: #666;
   --icon-input-active-background: #fff;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export * from './IconPicker.js'
 export * from './BootstrapIconPicker.js'
-export * from './ScrivitoBootstrapIconEditor.js'
+export * from './ScrivitoBootstrapIconPicker.js'


### PR DESCRIPTION
It looks like, the source code on npm is coming from a local copy of the repository.

This PR tries to restore the code from the npm package.

* scrivito-icon-editor => @justrelate/icon-picker
* Adjusted readme
* Change version to 1.0.0.
* Renamed ScrivitoBootstrapIconEditor to ScrivitoBootstrapIconPicker.
* Renamed ScrivitoIconEditor.css => ScrivitoIconPicker.css