### PR TITLE
Render without padding

### DIFF
--- a/src/ScrivitoIconPicker.css
+++ b/src/ScrivitoIconPicker.css
@@ -23,7 +23,6 @@
     Helvetica,
     Arial,
     sans-serif;
-  padding: 15px;
 
   .description {
     color: var(--icon-description-color);
@@ -210,7 +209,5 @@
     --icon-select-button-color: #ddd;
     --icon-select-button-hover-background: rgba(222, 222, 222, 0.2);
     --icon-select-button-hover-color: #fff;
-
-    padding: 7px;
   }
 }


### PR DESCRIPTION
Makes the picker fit more seamlessly into the UI.

Avoids workarounds like https://github.com/Scrivito/scrivito-portal-app/blob/0e255dcb582ce992455aa90cdcc3b8deed939e22/src/Components/ScrivitoExtensions/ScrivitoBootstrapIconPicker.tsx#L19