### PR TITLE
Update styles for CB re-design / DAM

### DIFF
--- a/src/ScrivitoIconPicker.css
+++ b/src/ScrivitoIconPicker.css
@@ -4,10 +4,10 @@
   --icon-description-color: #666;
   --icon-input-active-background: #fff;
   --icon-input-active-color: #555;
-  --icon-input-background: #fff;
-  --icon-input-color: #555;
+  --icon-input-background: rgba(0, 0, 0, 0.07);
+  --icon-input-color: rgba(0, 0, 0, 0.95);
   --icon-input-placeholder-color: #999;
-  --icon-preview-background: rgba(255, 255, 255, 0.8);
+  --icon-preview-background: rgba(0, 0, 0, 0.07);
   --icon-preview-color: #444;
   --icon-preview-title-font-size: 13px;
   --icon-preview-title-shadow: none;
@@ -54,6 +54,7 @@
   .icon-preview {
     align-items: center;
     background: var(--icon-preview-background);
+    border: 1px solid rgba(0, 0, 0, 0.19);
     border-radius: 4px;
     color: var(--icon-preview-color);
     display: inline-flex;
@@ -113,7 +114,8 @@
       border-radius: 23px 0 0 23px;
       color: var(--icon-input-color);
       font-size: 11px;
-      line-height: 25px;
+      border: 1px solid rgba(0, 0, 0, 0.19);
+      line-height: 23px;
       margin-right: 31px;
       padding: 1px 3px 1px 10px;
       transition: all 0.5s ease;
@@ -213,24 +215,4 @@
     --icon-select-button-hover-background: rgba(222, 222, 222, 0.2);
     --icon-select-button-hover-color: #fff;
   }
-}
-
-.scrivito-icon-picker {
-  & .icon-preview {
-    border: 1px solid rgba(0, 0, 0, 0.19);
-    background: rgba(0, 0, 0, 0.07);
-  }
-
-  & .icon-search {
-    & input {
-      color: rgba(0, 0, 0, 0.95);
-      border: 1px solid rgba(0, 0, 0, 0.19);
-      background: rgba(0, 0, 0, 0.07);
-      line-height: 23px;
-    }
-  }
-}
-
-.scrivito-icon-picker {
-  padding: 0;
 }

--- a/src/ScrivitoIconPicker.css
+++ b/src/ScrivitoIconPicker.css
@@ -214,3 +214,23 @@
     --icon-select-button-hover-color: #fff;
   }
 }
+
+.scrivito-icon-picker {
+  & .icon-preview {
+    border: 1px solid rgba(0, 0, 0, 0.19);
+    background: rgba(0, 0, 0, 0.07);
+  }
+
+  & .icon-search {
+    & input {
+      color: rgba(0, 0, 0, 0.95);
+      border: 1px solid rgba(0, 0, 0, 0.19);
+      background: rgba(0, 0, 0, 0.07);
+      line-height: 23px;
+    }
+  }
+}
+
+.scrivito-icon-picker {
+  padding: 0;
+}


### PR DESCRIPTION
https://docs.scrivito.com/fresh-look-rolling-out-across-all-products-cd3b6ab88b0efd71

See also https://github.com/infopark/scrivito_js/pull/12963
Provided by @agessler (however I had to adjust the line-height of the inputs)
### CB
<img width="303" height="242" alt="Bildschirmfoto 2026-04-07 um 13 11 44" src="https://github.com/user-attachments/assets/6dcac429-38ad-4ef8-9f99-96ccf7d130f1" />

### Sidebar
<img width="364" height="169" alt="Bildschirmfoto 2026-04-07 um 13 11 52" src="https://github.com/user-attachments/assets/222236a4-a030-421e-9d1f-425e9eabb144" />

### Dialog
<img width="747" height="222" alt="Bildschirmfoto 2026-04-07 um 13 12 05" src="https://github.com/user-attachments/assets/d2aaab27-986e-4fca-a6d7-f5bd821bfa20" />